### PR TITLE
Use strftime() in vim to parsing epoch time.

### DIFF
--- a/autoload/gitblame.vim
+++ b/autoload/gitblame.vim
@@ -55,8 +55,8 @@ function! gitblame#commit_summary(file, line)
 
     let author = matchstr(git_blame[1], 'author \zs.\+$')
     let author_mail = matchstr(git_blame[2], 'author-mail \zs.\+$')
-    let timeformat = ' "+%Y-%m-%d %H:%M:%S"'
-    let timestamp = split(s:system('date -r ' .matchstr(git_blame[3], 'author-time \zs.\+$') .timeformat), "\n")[0]
+    let timestamp = matchstr(git_blame[3], 'author-time \zs.\+$')
+    let timestamp = strftime("%Y %b %d %X", timestamp)
     let blank = ' '
 
     return '['.commit_hash[0:8].'] '.summary .blank .author_mail .blank .author .blank .'('.timestamp.')'

--- a/autoload/gitblame.vim
+++ b/autoload/gitblame.vim
@@ -55,7 +55,8 @@ function! gitblame#commit_summary(file, line)
 
     let author = matchstr(git_blame[1], 'author \zs.\+$')
     let author_mail = matchstr(git_blame[2], 'author-mail \zs.\+$')
-    let timestamp = strftime("%Y-%m-%d %H:%M:%S")
+    let timeformat = ' "+%Y-%m-%d %H:%M:%S"'
+    let timestamp = split(s:system('date -r ' .matchstr(git_blame[3], 'author-time \zs.\+$') .timeformat), "\n")[0]
     let blank = ' '
 
     return '['.commit_hash[0:8].'] '.summary .blank .author_mail .blank .author .blank .'('.timestamp.')'


### PR DESCRIPTION
Linux uses the GNU version of the date command, which is different
with MacOS. Specifically, MacOS use 'date -r seconds' while Linux
use 'data -d @seconds'.