### PR TITLE
feat(neovim): use virtual text

### DIFF
--- a/autoload/gitblame.vim
+++ b/autoload/gitblame.vim
@@ -1,6 +1,15 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+if has('nvim-0.3.2')
+    let s:ns = nvim_create_namespace('gitBlame')
+    let g:GBlameVirtualTextEnable = get(g:, 'GBlameVirtualTextEnable', 0)
+    let g:GBlameVirtualTextPrefix = get(g:, 'GBlameVirtualTextPrefix', '> ')
+    let g:GBlameVirtualTextDelay  = get(g:, 'GBlameVirtualTextDelay', 2000)
+ else
+    let g:GBlameVirtualTextEnable = 0
+ endif
+
 function! s:has_vimproc()
   if !exists('s:exists_vimproc')
     try
@@ -69,10 +78,17 @@ function! gitblame#echo()
     let l:line = line('.')
     let l:gb = gitblame#commit_summary(l:file, l:line)
     if has_key(l:gb, 'error')
-        echo '['.l:gb['error'].']'
+        let l:echoMsg = '['.l:gb['error'].']'
     else
-        echo '['.l:gb['commit_hash'][0:8].'] '.l:gb['summary'] .l:blank .l:gb['author_mail'] .l:blank .l:gb['author'] .l:blank .'('.l:gb['author_time'].')'
+        let l:echoMsg = '['.l:gb['commit_hash'][0:8].'] '.l:gb['summary'] .l:blank .l:gb['author_mail'] .l:blank .l:gb['author'] .l:blank .'('.l:gb['author_time'].')'
     endif
+    if (g:GBlameVirtualTextEnable)
+       let l:line = line('.')
+       let l:buffer = bufnr('')
+       call nvim_buf_set_virtual_text(l:buffer, s:ns, l:line-1, [[g:GBlameVirtualTextPrefix.l:echoMsg, 'GBlameMSG']], {})
+       call timer_start(g:GBlameVirtualTextDelay, { tid -> nvim_buf_clear_namespace(l:buffer, s:ns, 0, -1)})
+    endif
+    echo l:echoMsg
 endfunction
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
This PR bring a new feature, allowing the git-blame message to be printed using the new [virtual text](https://github.com/neovim/neovim/pull/8180) feature on neovim ([exemple here](https://github.com/neovim/neovim/issues/8068)).
When `gitblame#echo()` is called, if `g:GBlameVirtualTextEnable` is true, the message will also appear as a text overlay after the EOL.

For now, the message appreay for a given time (customizable using `g:GBlameVirtualTextDelay, default 2 seconds).

The style is customizable: 
* `g:GBlameVirtualTextprefix` at the beginning of the string
* `GBlameMG` for the highlight group

Using only minor modifications, it may be possible to make the message follow the cursor if some people are interested.

Charles