### PR TITLE
trim git commit message if message length > window width

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ See Git Blame information in the status bar for the currently selected line.
 
 ![](https://wx2.sinaimg.cn/large/bceaad1fly1frwfmv50ytj21kw0in42a.jpg)
 
+Additional Feature
+------------------
+
+This fork has the trim message length in the status line, mainly for users who use 1 line height to avoid git commit message > 1 line height and gets prompted to PRESS ENTER TO CONTINUE.
+
 Installation
 --------------
 
@@ -36,13 +41,13 @@ then simply copy and paste:
 Using [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```vim
-Plug 'zivyangll/git-blame.vim'
+Plug 'wotzhs/git-blame.vim'
 ```
 
 Using [Vundle](https://github.com/VundleVim/Vundle.vim)
 
 ```viml
-Plugin 'zivyangll/git-blame.vim'
+Plugin 'wotzhs/git-blame.vim'
 ```
 
 Manual binding

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Using [Vundle](https://github.com/VundleVim/Vundle.vim)
 Plugin 'zivyangll/git-blame.vim'
 ```
 
-Please setting bindings
+Manual binding
 -----------------
 
 ** You must push the map in your vimrc to avoid conflicts with other plugins you may have installed.: **
@@ -53,6 +53,17 @@ Please setting bindings
 ```vim
 nnoremap <Leader>s :<C-u>call gitblame#echo()<CR>
 ```
+
+Auto git blame on current line
+-----------------
+
+Taking the cue from [@Edo78](https://github.com/Edo78)'s [comment](https://github.com/zivyangll/git-blame.vim/issues/20#issuecomment-534526591), add the following to your `~/.vimrc`:
+
+```vim
+autocmd CursorHold * :call gitblame#echo()
+```
+
+This will display the git blame after the cursor is held momentarily.
 
 Quick start guide
 -----------------

--- a/autoload/gitblame.vim
+++ b/autoload/gitblame.vim
@@ -81,6 +81,10 @@ function! gitblame#echo()
         let l:echoMsg = '['.l:gb['error'].']'
     else
         let l:echoMsg = '['.l:gb['commit_hash'][0:8].'] '.l:gb['summary'] .l:blank .l:gb['author_mail'] .l:blank .l:gb['author'] .l:blank .'('.l:gb['author_time'].')'
+	let excess = strwidth(l:echoMsg) - winwidth(0)
+	if excess > 0
+	    let l:echoMsg = '['.l:gb['commit_hash'][0:8].'] '.l:gb['summary'][:strwidth(l:gb['summary'])-excess-5] .'...' .l:blank .l:gb['author_mail'] .l:blank .l:gb['author'] .l:blank .'('.l:gb['author_time'].')'
+	endif
     endif
     if (g:GBlameVirtualTextEnable)
        let l:ns = nvim_create_namespace('gitBlame'.b:GBlameVirtualTextCounter)


### PR DESCRIPTION
@zivyangll this PR trims the excessively long git commit message by the amount in excess of the current window width and replaced with ..., this is to avoid the `Press ENTER or type command to continue`