### PR TITLE
gitblame.vim: map <Plug>(GitBlame)

### DIFF
--- a/plugin/gitblame.vim
+++ b/plugin/gitblame.vim
@@ -4,3 +4,6 @@ endif
 let g:loaded_gitblame = 1
 
 command! -nargs=0 GitBlame call gitblame#echo()
+
+nnoremap <silent> <Plug>(GitBlame) :<C-u>GitBlame<CR>
+" nmap <silent> <Leader>s <Plug>(GitBlame)  " example


### PR DESCRIPTION
The default mappings where (rightly) removed in order not to interfere with users' preferred bindings. But the right way to solve the problem is to add a `<Plug>` mapping, which can then be bound to any key sequence.